### PR TITLE
Issue #899 Fix typo in developing.adoc

### DIFF
--- a/developing.adoc
+++ b/developing.adoc
@@ -66,7 +66,7 @@ First, one needs to set the following flags in `Makefile`, under `integration` t
 - `--bundle-location`: if bundle is embedded, this flag should be set to `--bundle-location=embedded` or not passed at all; if bundle is not embedded, then absolute path to the bundle should be passed.
 - `--crc-binary`: if `crc` binary resides in `$GOPATH/bin`, then this flag needs not be passed; otherwise absolute path to the `crc` binary should be passed.
 
-To start integrationt tests, run:
+To start integration tests, run:
 ```bash
 $ make integration
 ```


### PR DESCRIPTION
Fixes: https://github.com/code-ready/crc/issues/899